### PR TITLE
support kenlm models and surprisal from them

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -187,11 +187,11 @@ python-versions = ">=3.7"
 numpy = ">=1.16"
 
 [package.extras]
-test-no-codebase = ["pillow", "matplotlib", "pytest"]
+bokeh = ["bokeh", "selenium"]
+docs = ["docutils (<0.18)", "sphinx", "sphinx-rtd-theme"]
+test = ["pytest", "matplotlib", "pillow", "flake8", "isort"]
 test-minimal = ["pytest"]
-test = ["isort", "flake8", "pillow", "matplotlib", "pytest"]
-docs = ["sphinx-rtd-theme", "sphinx", "docutils (<0.18)"]
-bokeh = ["selenium", "bokeh"]
+test-no-codebase = ["pytest", "matplotlib", "pillow"]
 
 [[package]]
 name = "cycler"
@@ -261,7 +261,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-tests = ["rich", "littleutils", "pytest", "asttokens"]
+tests = ["asttokens", "pytest", "littleutils", "rich"]
 
 [[package]]
 name = "fastjsonschema"
@@ -325,14 +325,14 @@ tqdm = "*"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-torch = ["torch"]
-testing = ["soundfile", "pytest-cov", "pytest", "jinja2", "jedi", "isort (>=5.5.4)", "InquirerPy (==0.3.4)"]
-tensorflow = ["graphviz", "pydot", "tensorflow"]
-quality = ["mypy", "isort (>=5.5.4)", "flake8-bugbear", "flake8 (>=3.8.3)", "black (==22.3)"]
-fastai = ["fastcore (>=1.3.27)", "fastai (>=2.4)", "toml"]
-dev = ["mypy", "flake8-bugbear", "flake8 (>=3.8.3)", "black (==22.3)", "soundfile", "pytest-cov", "pytest", "jinja2", "jedi", "isort (>=5.5.4)", "InquirerPy (==0.3.4)"]
+all = ["InquirerPy (==0.3.4)", "isort (>=5.5.4)", "jedi", "jinja2", "pytest", "pytest-cov", "soundfile", "black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "mypy"]
 cli = ["InquirerPy (==0.3.4)"]
-all = ["mypy", "flake8-bugbear", "flake8 (>=3.8.3)", "black (==22.3)", "soundfile", "pytest-cov", "pytest", "jinja2", "jedi", "isort (>=5.5.4)", "InquirerPy (==0.3.4)"]
+dev = ["InquirerPy (==0.3.4)", "isort (>=5.5.4)", "jedi", "jinja2", "pytest", "pytest-cov", "soundfile", "black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "mypy"]
+fastai = ["toml", "fastai (>=2.4)", "fastcore (>=1.3.27)"]
+quality = ["black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "isort (>=5.5.4)", "mypy"]
+tensorflow = ["tensorflow", "pydot", "graphviz"]
+testing = ["InquirerPy (==0.3.4)", "isort (>=5.5.4)", "jedi", "jinja2", "pytest", "pytest-cov", "soundfile"]
+torch = ["torch"]
 
 [[package]]
 name = "idna"
@@ -565,6 +565,14 @@ description = "A JupyterLab extension."
 category = "dev"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "kenlm"
+version = "0.2.0"
+description = ""
+category = "main"
+optional = true
+python-versions = "*"
 
 [[package]]
 name = "kiwisolver"
@@ -814,14 +822,14 @@ python-versions = ">=3.8"
 
 [package.dependencies]
 numpy = [
-    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
     {version = ">=1.20.3", markers = "python_version < \"3.10\""},
+    {version = ">=1.21.0", markers = "python_version >= \"3.10\""},
 ]
 python-dateutil = ">=2.8.1"
 pytz = ">=2020.1"
 
 [package.extras]
-test = ["pytest-xdist (>=1.31)", "pytest (>=6.0)", "hypothesis (>=5.5.3)"]
+test = ["hypothesis (>=5.5.3)", "pytest (>=6.0)", "pytest-xdist (>=1.31)"]
 
 [[package]]
 name = "pandas-stubs"
@@ -1219,7 +1227,7 @@ executing = "*"
 pure-eval = "*"
 
 [package.extras]
-tests = ["cython", "littleutils", "pygments", "typeguard", "pytest"]
+tests = ["pytest", "typeguard", "pygments", "littleutils", "cython"]
 
 [[package]]
 name = "terminado"
@@ -1348,6 +1356,7 @@ deepspeed-testing = ["deepspeed (>=0.6.5)", "accelerate (>=0.10.0)", "pytest", "
 dev = ["tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "torch (>=1.0)", "jax (>=0.2.8,!=0.3.2,<=0.3.6)", "jaxlib (>=0.1.65,<=0.3.6)", "flax (>=0.4.1)", "optax (>=0.0.8)", "sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "accelerate (>=0.10.0)", "pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "evaluate (>=0.2.0)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "unidic-lite (>=1.0.7)", "unidic (>=1.0.2)", "hf-doc-builder", "scikit-learn"]
 dev-tensorflow = ["pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "evaluate (>=0.2.0)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "pillow", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "hf-doc-builder", "scikit-learn", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer"]
 dev-torch = ["pytest", "pytest-xdist", "timeout-decorator", "parameterized", "psutil", "datasets", "dill (<0.3.5)", "evaluate (>=0.2.0)", "pytest-timeout", "black (==22.3)", "sacrebleu (>=1.4.12,<2.0.0)", "rouge-score (!=0.0.7,!=0.0.8,!=0.1,!=0.1.1)", "nltk", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)", "protobuf (<=3.20.1)", "sacremoses", "rjieba", "faiss-cpu", "cookiecutter (==1.7.3)", "torch (>=1.0)", "sentencepiece (>=0.1.91,!=0.1.92)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "fugashi (>=1.0)", "ipadic (>=1.0.0,<2.0)", "unidic-lite (>=1.0.7)", "unidic (>=1.0.2)", "hf-doc-builder", "scikit-learn", "onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
+retrieval = ["faiss-cpu", "datasets"]
 docs = ["tensorflow (>=2.3)", "onnxconverter-common", "tf2onnx", "tensorflow-text", "torch (>=1.0)", "jax (>=0.2.8,!=0.3.2,<=0.3.6)", "jaxlib (>=0.1.65,<=0.3.6)", "flax (>=0.4.1)", "optax (>=0.0.8)", "sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)", "tokenizers (>=0.11.1,!=0.11.3,<0.13)", "torchaudio", "librosa", "pyctcdecode (>=0.3.0)", "phonemizer", "pillow", "optuna", "ray", "sigopt", "timm", "codecarbon (==1.2.0)", "accelerate (>=0.10.0)", "hf-doc-builder"]
 docs_specific = ["hf-doc-builder"]
 fairscale = ["fairscale (>0.3)"]
@@ -1362,7 +1371,6 @@ onnxruntime = ["onnxruntime (>=1.4.0)", "onnxruntime-tools (>=1.4.2)"]
 optuna = ["optuna"]
 quality = ["black (==22.3)", "isort (>=5.5.4)", "flake8 (>=3.8.3)", "GitPython (<3.1.19)", "hf-doc-builder (>=0.3.0)"]
 ray = ["ray"]
-retrieval = ["faiss-cpu", "datasets"]
 sagemaker = ["sagemaker (>=2.31.0)"]
 sentencepiece = ["sentencepiece (>=0.1.91,!=0.1.92)", "protobuf (<=3.20.1)"]
 serving = ["pydantic", "uvicorn", "fastapi", "starlette"]
@@ -1443,7 +1451,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "195c96f4ce071b1d715948ebe707bbf0b1f58f4c2f5487e051f627a537ae070e"
+content-hash = "77fd300cc93c9e1fe48c25e9176a22939f7d4fa8725d1f28f270aa41f72522ce"
 
 [metadata.files]
 appnope = [
@@ -1512,7 +1520,10 @@ entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
-et-xmlfile = []
+et-xmlfile = [
+    {file = "et_xmlfile-1.1.0-py3-none-any.whl", hash = "sha256:a2ba85d1d6a74ef63837eed693bcb89c3f752169b0e3e7ae5b16ca5e1b3deada"},
+    {file = "et_xmlfile-1.1.0.tar.gz", hash = "sha256:8eb9e2bc2f8c97e37a2dc85a09ecdcdec9d8a396530a6d5a33b30b9a92da0c5c"},
+]
 exceptiongroup = []
 executing = []
 fastjsonschema = []
@@ -1543,6 +1554,7 @@ jupyter-client = []
 jupyter-core = []
 jupyterlab-pygments = []
 jupyterlab-widgets = []
+kenlm = []
 kiwisolver = []
 lxml = []
 markupsafe = [
@@ -1656,7 +1668,10 @@ pycparser = [
     {file = "pycparser-2.21.tar.gz", hash = "sha256:e644fdec12f7872f86c58ff790da456218b10f863970249516d60a5eaca77206"},
 ]
 pygments = []
-pyparsing = []
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
 pyrsistent = [
     {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
     {file = "pyrsistent-0.18.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d45866ececf4a5fff8742c25722da6d4c9e180daa7b405dc0a2a2790d668c26"},
@@ -1686,7 +1701,22 @@ python-dateutil = [
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pytz = []
-pywin32 = []
+pywin32 = [
+    {file = "pywin32-304-cp310-cp310-win32.whl", hash = "sha256:3c7bacf5e24298c86314f03fa20e16558a4e4138fc34615d7de4070c23e65af3"},
+    {file = "pywin32-304-cp310-cp310-win_amd64.whl", hash = "sha256:4f32145913a2447736dad62495199a8e280a77a0ca662daa2332acf849f0be48"},
+    {file = "pywin32-304-cp310-cp310-win_arm64.whl", hash = "sha256:d3ee45adff48e0551d1aa60d2ec066fec006083b791f5c3527c40cd8aefac71f"},
+    {file = "pywin32-304-cp311-cp311-win32.whl", hash = "sha256:30c53d6ce44c12a316a06c153ea74152d3b1342610f1b99d40ba2795e5af0269"},
+    {file = "pywin32-304-cp311-cp311-win_amd64.whl", hash = "sha256:7ffa0c0fa4ae4077e8b8aa73800540ef8c24530057768c3ac57c609f99a14fd4"},
+    {file = "pywin32-304-cp311-cp311-win_arm64.whl", hash = "sha256:cbbe34dad39bdbaa2889a424d28752f1b4971939b14b1bb48cbf0182a3bcfc43"},
+    {file = "pywin32-304-cp36-cp36m-win32.whl", hash = "sha256:be253e7b14bc601718f014d2832e4c18a5b023cbe72db826da63df76b77507a1"},
+    {file = "pywin32-304-cp36-cp36m-win_amd64.whl", hash = "sha256:de9827c23321dcf43d2f288f09f3b6d772fee11e809015bdae9e69fe13213988"},
+    {file = "pywin32-304-cp37-cp37m-win32.whl", hash = "sha256:f64c0377cf01b61bd5e76c25e1480ca8ab3b73f0c4add50538d332afdf8f69c5"},
+    {file = "pywin32-304-cp37-cp37m-win_amd64.whl", hash = "sha256:bb2ea2aa81e96eee6a6b79d87e1d1648d3f8b87f9a64499e0b92b30d141e76df"},
+    {file = "pywin32-304-cp38-cp38-win32.whl", hash = "sha256:94037b5259701988954931333aafd39cf897e990852115656b014ce72e052e96"},
+    {file = "pywin32-304-cp38-cp38-win_amd64.whl", hash = "sha256:ead865a2e179b30fb717831f73cf4373401fc62fbc3455a0889a7ddac848f83e"},
+    {file = "pywin32-304-cp39-cp39-win32.whl", hash = "sha256:25746d841201fd9f96b648a248f731c1dec851c9a08b8e33da8b56148e4c65cc"},
+    {file = "pywin32-304-cp39-cp39-win_amd64.whl", hash = "sha256:d24a3382f013b21aa24a5cfbfad5a2cd9926610c0affde3e8ab5b3d7dbcf4ac9"},
+]
 pywinpty = []
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -1726,7 +1756,27 @@ pyyaml = [
 pyzmq = []
 regex = []
 requests = []
-scipy = []
+scipy = [
+    {file = "scipy-1.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a15a1f3fc0abff33e792d6049161b7795909b40b97c6cc2934ed54384017ab76"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e79570979ccdc3d165456dd62041d9556fb9733b86b4b6d818af7a0afc15f092"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a423533c55fec61456dedee7b6ee7dce0bb6bfa395424ea374d25afa262be261"},
+    {file = "scipy-1.6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:33d6b7df40d197bdd3049d64e8e680227151673465e5d85723b3b8f6b15a6ced"},
+    {file = "scipy-1.6.1-cp37-cp37m-win32.whl", hash = "sha256:6725e3fbb47da428794f243864f2297462e9ee448297c93ed1dcbc44335feb78"},
+    {file = "scipy-1.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:5fa9c6530b1661f1370bcd332a1e62ca7881785cc0f80c0d559b636567fab63c"},
+    {file = "scipy-1.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:bd50daf727f7c195e26f27467c85ce653d41df4358a25b32434a50d8870fc519"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:f46dd15335e8a320b0fb4685f58b7471702234cba8bb3442b69a3e1dc329c345"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0e5b0ccf63155d90da576edd2768b66fb276446c371b73841e3503be1d63fb5d"},
+    {file = "scipy-1.6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2481efbb3740977e3c831edfd0bd9867be26387cacf24eb5e366a6a374d3d00d"},
+    {file = "scipy-1.6.1-cp38-cp38-win32.whl", hash = "sha256:68cb4c424112cd4be886b4d979c5497fba190714085f46b8ae67a5e4416c32b4"},
+    {file = "scipy-1.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:5f331eeed0297232d2e6eea51b54e8278ed8bb10b099f69c44e2558c090d06bf"},
+    {file = "scipy-1.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0c8a51d33556bf70367452d4d601d1742c0e806cd0194785914daf19775f0e67"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:83bf7c16245c15bc58ee76c5418e46ea1811edcc2e2b03041b804e46084ab627"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:794e768cc5f779736593046c9714e0f3a5940bc6dcc1dba885ad64cbfb28e9f0"},
+    {file = "scipy-1.6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:5da5471aed911fe7e52b86bf9ea32fb55ae93e2f0fac66c32e58897cfb02fa07"},
+    {file = "scipy-1.6.1-cp39-cp39-win32.whl", hash = "sha256:8e403a337749ed40af60e537cc4d4c03febddcc56cd26e774c9b1b600a70d3e4"},
+    {file = "scipy-1.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:a5193a098ae9f29af283dcf0041f762601faf2e595c0db1da929875b7570353f"},
+    {file = "scipy-1.6.1.tar.gz", hash = "sha256:c4fceb864890b6168e79b0e714c585dbe2fd4222768ee90bc1aa0f8218691b11"},
+]
 seaborn = [
     {file = "seaborn-0.11.2-py3-none-any.whl", hash = "sha256:85a6baa9b55f81a0623abddc4a26b334653ff4c6b18c418361de19dbba0ef283"},
     {file = "seaborn-0.11.2.tar.gz", hash = "sha256:cf45e9286d40826864be0e3c066f98536982baf701a7caa386511792d61ff4f6"},
@@ -1744,7 +1794,41 @@ soupsieve = []
 stack-data = []
 terminado = []
 tinycss2 = []
-tokenizers = []
+tokenizers = [
+    {file = "tokenizers-0.12.1-cp310-cp310-macosx_10_11_x86_64.whl", hash = "sha256:d737df0f8f26e093a82bfb106b6cfb510a0e9302d35834568e5b20b73ddc5a9c"},
+    {file = "tokenizers-0.12.1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f1271224acafb27639c432e1ce4e7d38eab40305ba1c546e871d5c8a32f4f195"},
+    {file = "tokenizers-0.12.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdeba37c2fb44e1aec8a72af4cb369655b59ba313181b1b4b8183f08e759c49c"},
+    {file = "tokenizers-0.12.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:53b5f4012ce3ffddd5b00827441b80dc7a0f6b41f4fc5248ae6d36e7d3920c6d"},
+    {file = "tokenizers-0.12.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5188e13fc09edfe05712ca3ae5a44e7f2b0137927b1ca210d0fad90d3e58315a"},
+    {file = "tokenizers-0.12.1-cp310-cp310-win32.whl", hash = "sha256:eff5ff411f18a201eec137b7b32fcb55e0c48b372d370bd24f965f5bad471fa4"},
+    {file = "tokenizers-0.12.1-cp310-cp310-win_amd64.whl", hash = "sha256:bdbca79726fe883c696088ea163715b2f902aec638a8e24bcf9790ff8fa45019"},
+    {file = "tokenizers-0.12.1-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:28825dade9e52ad464164020758f9d49eb7251c32b6ae146601c506a23c67c0e"},
+    {file = "tokenizers-0.12.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:91906d725cb84d8ee71ce05fbb155d39d494849622b4f9349e5176a8eb01c49b"},
+    {file = "tokenizers-0.12.1-cp36-cp36m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:230f51a0a82ca7b90077eaca2415f12ff9bd144607888b9c50c2ee543452322e"},
+    {file = "tokenizers-0.12.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8d4339c376b695de2ad8ccaebffa75e4dc1d7857be1103d80e7925b34af8cf78"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:27d93b712aa2d4346aa506ecd4ec9e94edeebeaf2d484357b482cdeffc02b5f5"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:7f4cb68dc538b52240d1986d2034eb0a6373be2ab5f0787d1be3ad1444ce71b7"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ae6c04b629ac2cd2f695739988cb70b9bd8d5e7f849f5b14c4510e942bee5770"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6a38b2019d4807d42afeff603a119094ee00f63bea2921136524c8814e9003f8"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fde8dccb9033fa344ffce3ee1837939a50e7a210a768f1cf2059beeafa755481"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-win32.whl", hash = "sha256:38625595b2fd37bfcce64ff9bfb6868c07e9a7b7f205c909d94a615ce9472287"},
+    {file = "tokenizers-0.12.1-cp37-cp37m-win_amd64.whl", hash = "sha256:01abe6fbfe55e4131ca0c4c3d1a9d7ef5df424a8d536e998d2a4fc0bc57935f4"},
+    {file = "tokenizers-0.12.1-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:7c5c54080a7d5c89c990e0d478e0882dbac88926d43323a3aa236492a3c9455f"},
+    {file = "tokenizers-0.12.1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:419d113e3bcc4fe20a313afc47af81e62906306b08fe1601e1443d747d46af1f"},
+    {file = "tokenizers-0.12.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b9779944559cb7ace6a8516e402895f239b0d9d3c833c67dbaec496310e7e206"},
+    {file = "tokenizers-0.12.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7d43de14b4469b57490dbaf136a31c266cb676fa22320f01f230af9219ae9034"},
+    {file = "tokenizers-0.12.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:258873634406bd1d438c799993a5e44bbc0132ff055985c03c4fe30f702e9a33"},
+    {file = "tokenizers-0.12.1-cp38-cp38-win32.whl", hash = "sha256:3f2647cc256d6a53d18b9dcd71d377828e9f8991fbcbd6fcd8ca2ceb174552b0"},
+    {file = "tokenizers-0.12.1-cp38-cp38-win_amd64.whl", hash = "sha256:62a723bd4b18bc55121f5c34cd8efd6c651f2d3b81f81dd50e5351fb65b8a617"},
+    {file = "tokenizers-0.12.1-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:411ebc89228f30218ffa9d9c49d414864b0df5026a47c24820431821c4360460"},
+    {file = "tokenizers-0.12.1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:619728df2551bdfe6f96ff177f9ded958e7ed9e2af94c8d5ac2834d1eb06d112"},
+    {file = "tokenizers-0.12.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8cea98f3f9577d1541b7bb0f7a3308a911751067e1d83e01485c9d3411bbf087"},
+    {file = "tokenizers-0.12.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:664f36f0a0d409c24f2201d495161fec4d8bc93e091fbb78814eb426f29905a3"},
+    {file = "tokenizers-0.12.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0bf2380ad59c50222959a9b6f231339200a826fc5cb2be09ff96d8a59f65fc5e"},
+    {file = "tokenizers-0.12.1-cp39-cp39-win32.whl", hash = "sha256:6a7a106d04154c2159db6cd7d042af2e2e0e53aee432f872fe6c8be45100436a"},
+    {file = "tokenizers-0.12.1-cp39-cp39-win_amd64.whl", hash = "sha256:2158baf80cbc09259bfd6e0e0fc4597b611e7a72ad5443dad63918a90f1dd304"},
+    {file = "tokenizers-0.12.1.tar.gz", hash = "sha256:070746f86efa6c873db341e55cf17bb5e7bdd5450330ca8eca542f5c3dab2c66"},
+]
 tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -762,8 +762,8 @@ test = ["pytest", "coverage", "requests", "testpath", "nbval", "selenium", "pyte
 
 [[package]]
 name = "numpy"
-version = "1.23.3"
-description = "NumPy is the fundamental package for array computing with Python."
+version = "1.24.4"
+description = "Fundamental package for array computing in Python"
 category = "main"
 optional = false
 python-versions = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ plotext = "^5.0.2"
 matplotlib = "^3.5.2"
 pandas = "^1.4.3"
 openai = "^0.23.0"
+kenlm = {version = "^0.2.0", optional = true}
 
 [tool.poetry.dev-dependencies]
 ipython = "^8.4.0"

--- a/surprisal/__init__.py
+++ b/surprisal/__init__.py
@@ -4,6 +4,7 @@ from surprisal.model import (
     CausalHuggingFaceModel,
     MaskedHuggingFaceModel,
     OpenAIModel,
+    KenLMModel,
 )
 
 from surprisal.interface import SurprisalQuantity

--- a/surprisal/interface.py
+++ b/surprisal/interface.py
@@ -153,7 +153,7 @@ class CustomEncoding:
         self.tokens = tokens
         self.spans = spans
         self.original_str = original_str
-        self.ids = ids
+        self._ids = ids
 
     def token_to_chars(self, token_index) -> typing.Tuple[int, int]:
         """
@@ -206,6 +206,6 @@ class CustomEncoding:
             :obj:`List[int]`: The list of IDs
         """
         # IDs are not applicable to non-LM tokenization, unless explicitly specified
-        if self.ids:
-            return self.ids
+        if self._ids:
+            return self._ids
         return [0] * len(self.tokens)

--- a/surprisal/interface.py
+++ b/surprisal/interface.py
@@ -74,3 +74,22 @@ class SurprisalArray(ABC):
             a.annotate(t, (i, arr[i]))
 
         return f, a
+
+
+class CustomEncoding:
+    """
+    a duck-typed clone of the huggingface tokenizers' return class
+        `tokenizers.Encoding`
+    that packages simple custom-tokenized text together with its
+    character and word spans allowing indexing into the tokenized
+    object by character and word spans
+
+    the goal is for this class to be capable of being passed to
+    `hf_pick_matching_token_ixs` with the signature
+
+    ```python
+    hf_pick_matching_token_ixs(
+        encoding: "tokenizers.Encoding", span_of_interest: slice, span_type: str
+    ) -> slice
+    ```
+    """

--- a/surprisal/interface.py
+++ b/surprisal/interface.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod, abstractclassmethod, abstractproperty
 import typing
+import tokenizers.Encoding
 
 
 class Model(ABC):
@@ -76,7 +77,7 @@ class SurprisalArray(ABC):
         return f, a
 
 
-class CustomEncoding:
+class CustomEncoding(tokenizers.Encoding):
     """
     a duck-typed clone of the huggingface tokenizers' return class
         `tokenizers.Encoding`
@@ -86,10 +87,66 @@ class CustomEncoding:
 
     the goal is for this class to be capable of being passed to
     `hf_pick_matching_token_ixs` with the signature
-
     ```python
-    hf_pick_matching_token_ixs(
+    surprisal.utils.hf_pick_matching_token_ixs(
         encoding: "tokenizers.Encoding", span_of_interest: slice, span_type: str
     ) -> slice
     ```
+    and that's about it. it does not provide implementations of anything else,
+    since huggingface makes it really difficult to actually re-use any of the
+    Rust implementation of tokeizers in Python
     """
+
+    def __init__(
+        self,
+        tokens: typing.Iterable[str],
+        spans: typing.Iterable[typing.Tuple[int]],
+        original_str: str,
+    ) -> None:
+        self.tokens = tokens
+        self.spans = spans
+        self.original_str = original_str
+
+    def token_to_chars(self, token_index):
+        """
+        Get the offsets of the token at the given index.
+
+        The returned offsets are related to the input sequence that contains the
+        token.  In order to determine in which input sequence it belongs, you
+        must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
+
+        Args:
+            token_index (:obj:`int`):
+                The index of a token in the encoded sequence.
+
+        Returns:
+            :obj:`Tuple[int, int]`: The token offsets :obj:`(first, last + 1)`
+        """
+
+    def token_to_word(self):
+        """
+        Get the index of the word that contains the token in one of the input sequences.
+
+        The returned word index is related to the input sequence that contains
+        the token.  In order to determine in which input sequence it belongs, you
+        must call :meth:`~tokenizers.Encoding.token_to_sequence()`.
+
+        Args:
+            token_index (:obj:`int`):
+                The index of a token in the encoded sequence.
+
+        Returns:
+            :obj:`int`: The index of the word in the relevant input sequence.
+        """
+
+    @property
+    def ids(self):
+        """
+        The generated IDs
+
+        The IDs are the main input to a Language Model. They are the token indices,
+        the numerical representations that a LM understands.
+
+        Returns:
+            :obj:`List[int]`: The list of IDs
+        """

--- a/surprisal/interface.py
+++ b/surprisal/interface.py
@@ -77,7 +77,7 @@ class SurprisalArray(ABC):
         return f, a
 
 
-class CustomEncoding(tokenizers.Encoding):
+class CustomEncoding:
     """
     a duck-typed clone of the huggingface tokenizers' return class
         `tokenizers.Encoding`

--- a/surprisal/interface.py
+++ b/surprisal/interface.py
@@ -2,7 +2,6 @@
 
 from abc import ABC, abstractmethod, abstractclassmethod, abstractproperty
 import typing
-import tokenizers.Encoding
 
 
 class Model(ABC):

--- a/surprisal/model.py
+++ b/surprisal/model.py
@@ -57,6 +57,9 @@ class KenLMModel(Model):
     ) -> typing.List[NGramSurprisal]:
         import kenlm
 
+        if type(textbatch) is str:
+            textbatch = [textbatch]
+
         def score_sent(
             sent: CustomEncoding,
             m: kenlm.Model = self.model,
@@ -82,9 +85,7 @@ class KenLMModel(Model):
 
         accumulator = []
         for b in range(len(textbatch)):
-            accumulator += [
-                NGramSurprisal(tokens=tokenized[b], surprisals=-scores[b].numpy())
-            ]
+            accumulator += [NGramSurprisal(tokens=tokenized[b], surprisals=-scores[b])]
         return accumulator
 
 

--- a/surprisal/model.py
+++ b/surprisal/model.py
@@ -10,12 +10,57 @@ from transformers import (
     AutoTokenizer,
     PreTrainedModel,
 )
+from tokenizers.pre_tokenizers import Whitespace, PreTokenizer
 
 from surprisal.utils import pick_matching_token_ixs, openai_models_list
 from surprisal.interface import Model, SurprisalArray, SurprisalQuantity
 from surprisal.surprisal import HuggingFaceSurprisal
 
 logger = logging.getLogger(name="surprisal")
+
+
+class KenLMModel(Model):
+    """
+    A class utilizing the `kenlm` library to compute surprisal using
+    pretrained kenlm models
+    """
+
+    def __init__(self, model_path: typing.Union[str, Path], **kwargs) -> None:
+        super().__init__(str(model_path))
+
+        import kenlm
+
+        self.tokenizer = Whitespace()
+
+        self.model = kenlm.Model(self.model_path)
+        self.state_in = kenlm.State()
+        self.state_out = kenlm.State()
+
+    def tokenize(self, textbatch: typing.Union[typing.List, str]):
+        if type(textbatch) is str:
+            textbatch = [textbatch]
+
+        self.tokenizer.pre_tokenize_str
+
+        raise NotImplementedError
+
+    def surprise(self, textbatch: typing.Union[typing.List, str]) -> SurprisalArray:
+        import kenlm
+
+        def score_sent(m: kenlm.Model, sent: str, bos: bool = True, eos: bool = True):
+            st1, st2 = kenlm.State(), kenlm.State()
+            if bos:
+                m.BeginSentenceWrite(st1)
+            else:
+                m.NullContextWrite(st1)
+            words = sent.split()
+            accum = []
+            for w in words:
+                accum += [m.BaseScore(st1, w, st2)]
+                st1, st2 = st2, st1
+            if eos:
+                accum += [m.BaseScore(st1, "</s>", st2)]
+            return sum(accum), accum
 
 
 ###############################################################################

--- a/surprisal/model.py
+++ b/surprisal/model.py
@@ -2,8 +2,10 @@ import typing
 import logging
 from abc import abstractmethod
 from functools import partial
+from pathlib import Path
 
 import numpy as np
+import numpy.typing
 from transformers import (
     AutoModelForCausalLM,
     AutoModelForMaskedLM,
@@ -32,7 +34,7 @@ class KenLMModel(Model):
 
         self.tokenizer = Whitespace()
 
-        self.model = kenlm.Model(self.model_path)
+        self.model = kenlm.Model(model_path)
         self.state_in = kenlm.State()
         self.state_out = kenlm.State()
 

--- a/surprisal/model.py
+++ b/surprisal/model.py
@@ -12,7 +12,7 @@ from transformers import (
 )
 from tokenizers.pre_tokenizers import Whitespace, PreTokenizer
 
-from surprisal.utils import pick_matching_token_ixs, openai_models_list
+from surprisal.utils import hf_pick_matching_token_ixs, openai_models_list
 from surprisal.interface import Model, SurprisalArray, SurprisalQuantity
 from surprisal.surprisal import HuggingFaceSurprisal
 

--- a/surprisal/surprisal.py
+++ b/surprisal/surprisal.py
@@ -37,7 +37,9 @@ class HuggingFaceSurprisal(SurprisalArray):
     def __iter__(self) -> typing.Tuple[str, float]:
         return zip(self.tokens, self.surprisals)
 
-    def __getitem__(self, slctup: typing.Tuple[typing.Union[slice, int], str]):
+    def __getitem__(
+        self, slctup: typing.Tuple[typing.Union[slice, int], str]
+    ) -> SurprisalQuantity:
         """Returns the aggregated surprisal over a character
 
         Args:
@@ -58,9 +60,9 @@ class HuggingFaceSurprisal(SurprisalArray):
             slc, slctype = slctup, "char"
 
         if slctype == "char":
-            fn = partial(pick_matching_token_ixs, span_type="char")
+            fn = partial(hf_pick_matching_token_ixs, span_type="char")
         elif slctype == "word":
-            fn = partial(pick_matching_token_ixs, span_type="word")
+            fn = partial(hf_pick_matching_token_ixs, span_type="word")
 
         if type(slc) is int:
             slc = slice(slc, slc + 1)
@@ -69,17 +71,6 @@ class HuggingFaceSurprisal(SurprisalArray):
         return SurprisalQuantity(
             self.surprisals[token_slc].sum(), " ".join(self.tokens[token_slc])
         )
-
-    def __repr__(self) -> str:
-        numfmt = "{: >10.3f}"
-        strfmt = "{: >10}"
-        accumulator = ""
-        for t in self.tokens:
-            accumulator += strfmt.format(t[:10]) + " "
-        accumulator += "\n"
-        for s in self.surprisals:
-            accumulator += numfmt.format(s) + " "
-        return accumulator
 
 
 class NGramSurprisal(HuggingFaceSurprisal):

--- a/surprisal/surprisal.py
+++ b/surprisal/surprisal.py
@@ -5,7 +5,7 @@ from functools import partial
 
 import numpy as np
 from surprisal.utils import hf_pick_matching_token_ixs
-from surprisal.interface import Model, SurprisalArray, SurprisalQuantity
+from surprisal.interface import CustomEncoding, Model, SurprisalArray, SurprisalQuantity
 
 logger = logging.getLogger(name="surprisal")
 
@@ -76,17 +76,10 @@ class HuggingFaceSurprisal(SurprisalArray):
 class NGramSurprisal(HuggingFaceSurprisal):
     def __init__(
         self,
-        tokens: typing.List[str],
+        tokens: typing.List[CustomEncoding],
         surprisals: np.ndarray,
     ) -> None:
-        super().__init__()
-
-        self._tokens: typing.List[str] = tokens
-        self._surprisals: surprisals.astype(SurprisalQuantity)
-
-    @property
-    def tokens(self) -> typing.List[str]:
-        return self._tokens
+        super().__init__(tokens, surprisals.astype(SurprisalQuantity))
 
     def __getitem__(
         self, slctup: typing.Tuple[typing.Union[slice, int], typing.Optional[str]]

--- a/surprisal/surprisal.py
+++ b/surprisal/surprisal.py
@@ -4,7 +4,7 @@ from abc import abstractmethod
 from functools import partial
 
 import numpy as np
-from surprisal.utils import pick_matching_token_ixs
+from surprisal.utils import hf_pick_matching_token_ixs
 from surprisal.interface import Model, SurprisalArray, SurprisalQuantity
 
 logger = logging.getLogger(name="surprisal")
@@ -31,7 +31,7 @@ class HuggingFaceSurprisal(SurprisalArray):
         return self._tokens.tokens
 
     @property
-    def surprisals(self):
+    def surprisals(self) -> np.typing.NDArray[SurprisalQuantity]:
         return self._surprisals
 
     def __iter__(self) -> typing.Tuple[str, float]:
@@ -80,6 +80,58 @@ class HuggingFaceSurprisal(SurprisalArray):
         for s in self.surprisals:
             accumulator += numfmt.format(s) + " "
         return accumulator
+
+
+class NGramSurprisal(HuggingFaceSurprisal):
+    def __init__(
+        self,
+        tokens: typing.List[str],
+        surprisals: np.ndarray,
+    ) -> None:
+        super().__init__()
+
+        self._tokens: typing.List[str] = tokens
+        self._surprisals: surprisals.astype(SurprisalQuantity)
+
+    @property
+    def tokens(self) -> typing.List[str]:
+        return self._tokens
+
+    def __getitem__(
+        self, slctup: typing.Tuple[typing.Union[slice, int], typing.Optional[str]]
+    ):
+        """Returns the aggregated surprisal over a character
+
+        Args:
+            slctup (typing.Tuple[typing.Union[slice, int], str]):
+                `(slc, slctype) = slctup`: a tuple of a `slc` (slice) and a `slctype` (str).
+                `slc` gives the slice of the original string we want to aggregate surprisal over.
+                `slctype` indicates if it should be a "char" slice or a "word" slice.
+                if a character falls inside a token, then that entire token is included.
+
+        Returns:
+            float: the aggregated surprisal over the word span
+        """
+        try:
+            slc, slctype = slctup
+            if slctype not in ("word", "char"):
+                raise ValueError(f"unrecognized slice type {slctype}")
+        except TypeError:
+            # slctup is not a tuple, but just a slice or int
+            slc, slctype = slctup, "char"
+
+        if slctype == "char":
+            raise NotImplementedError('WIP; currently only supports "word" spans')
+            fn = partial(hf_pick_matching_token_ixs, span_type="char")
+        elif slctype == "word":
+            token_slc = slc
+
+        if type(slc) is int:
+            slc = slice(slc, slc + 1)
+
+        return SurprisalQuantity(
+            self.surprisals[token_slc].sum(), " ".join(self.tokens[token_slc])
+        )
 
 
 class PCFGSurprisal(SurprisalArray):

--- a/surprisal/utils.py
+++ b/surprisal/utils.py
@@ -1,3 +1,4 @@
+import tokenizers
 from transformers import tokenization_utils_base
 
 

--- a/surprisal/utils.py
+++ b/surprisal/utils.py
@@ -1,7 +1,7 @@
 from transformers import tokenization_utils_base
 
 
-def pick_matching_token_ixs(
+def hf_pick_matching_token_ixs(
     encoding: "tokenizers.Encoding", span_of_interest: slice, span_type: str
 ) -> slice:
     """Picks token indices in a tokenized encoded sequence that best correspond to


### PR DESCRIPTION
in this PR we add support for [KenLM](https://github.com/kpu/kenlm) models using the KenLM python bindings. note that due to the complications of installing KenLM we don't enforce it as a requirement for the repo, but it should be installed if someone wants to use this library to do inference with KenLM Ngram models using the `kenlm` python interface